### PR TITLE
feat(delete-task): implement endpoint to delete a task

### DIFF
--- a/src/main/java/com/ndungutse/tms/controller/TaskApiController.java
+++ b/src/main/java/com/ndungutse/tms/controller/TaskApiController.java
@@ -2,6 +2,7 @@ package com.ndungutse.tms.controller;
 
 import java.io.*;
 import java.util.List;
+import java.util.UUID;
 
 import com.ndungutse.tms.Utils.TaskJsonMapper;
 import com.ndungutse.tms.dot.AllTasksResponse;
@@ -65,11 +66,36 @@ public class TaskApiController extends HttpServlet {
         response.getWriter().write("{ \"message\": \"Task updated\" }");
     }
 
+
     @Override
     protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        response.setContentType("application/json");
-        response.getWriter().write("{ \"message\": \"Task deleted\" }");
+        System.out.println("********************** Delete Here");
+        String idParam = request.getParameter("id");
+        if (idParam == null || idParam.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("{\"error\":\"Missing task ID\"}");
+            return;
+        }
+
+        try {
+            UUID taskId = UUID.fromString(idParam);
+            boolean deleted = taskService.deleteTaskById(taskId);
+
+            if (deleted) {
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            } else {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                response.getWriter().write("{\"error\":\"Task not found\"}");
+            }
+        } catch (IllegalArgumentException e) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.getWriter().write("{\"error\":\"Invalid UUID format\"}");
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.getWriter().write("{\"error\":\"" + e.getMessage() + "\"}");
+        }
     }
+
 
     public void destroy() {
     }

--- a/src/main/java/com/ndungutse/tms/repository/TaskRepository.java
+++ b/src/main/java/com/ndungutse/tms/repository/TaskRepository.java
@@ -81,4 +81,18 @@ public class TaskRepository {
         }
         return taskDTOS;
     }
+
+    // Delete Task
+    public boolean deleteById(UUID id) throws SQLException, ClassNotFoundException {
+        String sql = "DELETE FROM tasks WHERE id = ?";
+        try (
+                Connection conn = DBUtil.getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql);
+        ) {
+            stmt.setObject(1, id);
+            int affectedRows = stmt.executeUpdate();
+            return affectedRows > 0;
+        }
+    }
+
 }

--- a/src/main/java/com/ndungutse/tms/service/TaskService.java
+++ b/src/main/java/com/ndungutse/tms/service/TaskService.java
@@ -4,6 +4,7 @@ import com.ndungutse.tms.dot.TaskDTO;
 import com.ndungutse.tms.repository.TaskRepository;
 
 import java.util.List;
+import java.util.UUID;
 
 public class TaskService {
     private final TaskRepository taskRepository;
@@ -25,5 +26,10 @@ public class TaskService {
     // Get All Tasks
     public List<TaskDTO> getAllTasks(String status, String dueDateSortDirection) throws Exception {
         return taskRepository.findAll(status, dueDateSortDirection);
+    }
+
+    // Delete task
+    public boolean deleteTaskById(UUID id) throws Exception {
+        return taskRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to delete tasks by their unique ID, including updates to the API controller, service layer, and repository layer. The changes ensure proper error handling and database interaction for task deletion.

### API Enhancements:
* `TaskApiController` (`doDelete` method): Implemented task deletion logic, including parsing the task ID from the request, validating its format, and handling various response statuses (e.g., `400 Bad Request`, `404 Not Found`, `204 No Content`, `500 Internal Server Error`). Added detailed error messages for invalid or missing IDs.

### Service Layer Updates:
* [`TaskService`](diffhunk://#diff-22732894cbc35a04c3d68669c5b6517ea528a5a67e780b9d5dcc692a22198235R30-R34): Added `deleteTaskById(UUID id)` method to delegate task deletion requests to the repository layer.

### Repository Layer Updates:
* [`TaskRepository`](diffhunk://#diff-aeece004c16e9e9e93ed48c95347d5912883dd463449d04cc39944e842023847R84-R97): Added `deleteById(UUID id)` method to execute a SQL `DELETE` query for removing tasks by their ID, returning a boolean to indicate success.